### PR TITLE
fix: use GetByteData() to prevent error when uploading bigger files

### DIFF
--- a/Apps.Lexeri/Actions/ImportActions.cs
+++ b/Apps.Lexeri/Actions/ImportActions.cs
@@ -19,9 +19,10 @@ public class ImportActions(InvocationContext invocationContext, IFileManagementC
     public async Task<Import> CheckText([ActionParameter] CreateImportRequest input)
     {
       var fileStream = await fileManagementClient.DownloadAsync(input.Document);
+      var bytes = await fileStream.GetByteData();
 
       var uploadRequest = new LexeriUploadRequest();
-      uploadRequest.AddFile("file", () => fileStream, input.Document.Name);
+      uploadRequest.AddFile("file", bytes, input.Document.Name);
 
       var uploadResponse = await Client.ExecuteWithJson<UploadedDocument>(uploadRequest);
 

--- a/Apps.Lexeri/Actions/TermCheckActions.cs
+++ b/Apps.Lexeri/Actions/TermCheckActions.cs
@@ -47,7 +47,8 @@ public class TermCheckActions(InvocationContext invocationContext, IFileManageme
     //     var fileBytes = fileManagementClient.DownloadAsync(input.Document).Result.GetByteData().Result;
 
     //     var uploadRequest = new LexeriUploadRequest();
-    //     uploadRequest.AddFile("file", fileBytes, input.Document.Name);
+    //     var bytes = await fileStream.GetByteData();
+    //     uploadRequest.AddFile("file", bytes, input.Document.Name);
 
     //     var uploadResponse = await Client.ExecuteWithJson<UploadedDocument>(uploadRequest);
 

--- a/Apps.Lexeri/Actions/TermExtractionActions.cs
+++ b/Apps.Lexeri/Actions/TermExtractionActions.cs
@@ -26,9 +26,10 @@ public class TermExtractionActions(InvocationContext invocationContext, IFileMan
         }
 
         var fileStream = await fileManagementClient.DownloadAsync(file);
+        var bytes = await fileStream.GetByteData();
 
         var uploadRequest = new LexeriUploadRequest();
-        uploadRequest.AddFile("file", () => fileStream, file.Name);
+        uploadRequest.AddFile("file", bytes, file.Name);
 
         var uploadResponse = await Client.ExecuteWithJson<UploadedDocument>(uploadRequest);
 

--- a/Apps.Lexeri/Actions/TermRequestActions.cs
+++ b/Apps.Lexeri/Actions/TermRequestActions.cs
@@ -38,9 +38,10 @@ public class TermRequestActions(InvocationContext invocationContext, IFileManage
           }
 
           var fileStream = await fileManagementClient.DownloadAsync(file);
+          var bytes = await fileStream.GetByteData();
 
           var uploadRequest = new LexeriUploadRequest();
-          uploadRequest.AddFile("file", () => fileStream, file.Name);
+          uploadRequest.AddFile("file", bytes, file.Name);
 
           var uploadResponse = await Client.ExecuteWithJson<UploadedDocument>(uploadRequest);
 

--- a/Apps.Lexeri/Apps.Lexeri.csproj
+++ b/Apps.Lexeri/Apps.Lexeri.csproj
@@ -5,7 +5,7 @@
         <Nullable>enable</Nullable>
         <Product>Lexeri</Product>
         <Description>Lexeri is a collaborative terminology management solution that makes terminonology accessible to everyone.</Description>
-        <Version>1.0.0</Version>
+        <Version>1.0.1</Version>
         <PackageId>Apps.Lexeri.Tests.com</PackageId>
         <AssemblyName>Apps.Lexeri.Tests.com</AssemblyName>
         <RootNamespace>Apps.Lexeri.Tests.com</RootNamespace>


### PR DESCRIPTION
This fixes a bug in the previous version that caused the file upload to fail for bigger files